### PR TITLE
Python 3.x compatability

### DIFF
--- a/profilestats.py
+++ b/profilestats.py
@@ -15,8 +15,9 @@ def profile(fn=None):
             profiler.dump_stats('profilestats.prof')
             stats = pstats.Stats(profiler)
             conv = pyprof2calltree.CalltreeConverter(stats)
-            with file('cachegrind.out.profilestats', "wb") as f:
-                conv.output(f)
+            f = open('cachegrind.out.profilestats', "w")
+            conv.output(f)
+            f.close()
             stats.strip_dirs().sort_stats('cumulative').print_stats(10)
         return result
     return decorator

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,11 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
+        'Programming Language :: Python :: 2.5',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.2',
+        'Programming Language :: Python :: 3.3',
     ],
     license='BSD',
     install_requires=[


### PR DESCRIPTION
I made some small modifications to make `profilestats` run on Python 3.x.

They all concern the opening of the output file:

``` python
            with file('cachegrind.out.profilestats', "wb") as f:
                conv.output(f)
```
- `file` isn't a builtin on Python 3.x any more - using `open()` instead
- Change the file mode to `'w'` - writing to a `BufferedWriter` instance open in `'wb'` mode on 3.x doesn't work, and the file content is actually text, not binary. 
- Python 2.5 doesn't support the `with` statement yet.

So I rewrote it as:

``` python
            f = open('cachegrind.out.profilestats', "w")
            conv.output(f)
            f.close()
```

With these changes, I was able to install and use `profilestats` on Python 3.3 (with a patched source version of `pyprof2calltree` which I also made a [pull-request](https://github.com/pwaller/pyprof2calltree/pull/2) for). I checked that it (still) works on all the Python versions declared in the trove classifiers, which are:
- `Programming Language :: Python :: 2.5`
- `Programming Language :: Python :: 2.6`
- `Programming Language :: Python :: 2.7`
- `Programming Language :: Python :: 3.2`
- `Programming Language :: Python :: 3.3`
