### PR TITLE
Add profiling of threads

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,3 +35,15 @@ You can pass the following arguments to the decorator:
 
 * `callgrind_filename` (default: 'callgrind.out') - The filename for
   the profile data in k/qcachegrind's format.
+
+* `dump_dir` (default: '') - The path to put dumps in
+
+* `generate_callgrind` (default: True) - Whether or not to generate
+  callgrind dumps
+
+* `generate_profile` (default: True) - Whether or not to generate
+  profile dumps
+
+* `profile_per_thread` (default: False) - Generate a profile per
+  thread, using the thread name and putting them in the selected
+  dump_dir with the filename <threadname>.<type_filename_as_specified>

--- a/profilestats.py
+++ b/profilestats.py
@@ -1,6 +1,8 @@
 from cProfile import Profile
 from functools import wraps
 import pstats
+import os
+import threading
 
 import pyprof2calltree
 
@@ -9,24 +11,45 @@ profiler = Profile()
 
 def profile(cumulative=True, print_stats=0, sort_stats='cumulative',
             dump_stats=False, profile_filename='profilestats.out',
-            callgrind_filename='callgrind.out'):
+            callgrind_filename='callgrind.out', dump_dir='',
+            generate_callgrind=True, generate_profile=True,
+            profile_per_thread=False):
     def closure(func):
         @wraps(func)
         def decorator(*args, **kwargs):
             result = None
+            current_thread = threading.current_thread()
             if cumulative:
-                global profiler
+                if profile_per_thread:
+                    tls = threading.local()
+                    if not hasattr(tls, 'profiler'):
+                        tls.profiler = Profile()
+                    profiler = tls.profiler
+                else:
+                    global profiler
             else:
                 profiler = Profile()
             try:
                 result = profiler.runcall(func, *args, **kwargs)
             finally:
                 if dump_stats:
-                    profiler.dump_stats(profile_filename)
+                    if generate_profile:
+                        if profile_per_thread:
+                            profile_path = os.path.join(dump_dir, '%s.%s' % (current_thread.name, profile_filename))
+                        else:
+                            profile_path = os.path.join(dump_dir, profile_filename)
+                        profiler.dump_stats(profile_path)
+
                 stats = pstats.Stats(profiler)
                 conv = pyprof2calltree.CalltreeConverter(stats)
-                with open(callgrind_filename, 'w') as fd:
-                    conv.output(fd)
+                if generate_callgrind:
+                    if profile_per_thread:
+                        callgrind_path = os.path.join(dump_dir, '%s.%s' % (current_thread.name, callgrind_filename))
+                    else:
+                        callgrind_path = os.path.join(dump_dir, callgrind_filename)
+
+                    with open(callgrind_path, 'w') as fd:
+                        conv.output(fd)
                 if print_stats:
                     stats.strip_dirs().sort_stats(
                         sort_stats).print_stats(print_stats)


### PR DESCRIPTION
Add profiling of threads and some options to put dumps in a particuar directory.

These options are non-breaking to the former API, but allow each thread to produce its own trace, as well as a little more control on which files are created and where.
