### PR TITLE
Remove unused setuptools dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ setup(
     ],
     license='BSD',
     install_requires=[
-        'setuptools',
         'pyprof2calltree',
     ],
     py_modules=['profilestats'],


### PR DESCRIPTION
`setuptools` or `pkg_resources` are not runtime dependency for `profilestats`, let's remove it.